### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## [0.1.1](https://github.com/QaidVoid/zsync-rs/compare/0.1.0...0.1.1) - 2026-03-24
+
+### Added
+
+- Add progress callback support for downloads - ([45ea884](https://github.com/QaidVoid/zsync-rs/commit/45ea884c758382f715353d4323c7dd473fe8d251))
+
+### Other
+
+- Add release profile - ([5de30ce](https://github.com/QaidVoid/zsync-rs/commit/5de30ce78bab9700a7cb10dfb9d3a3f0955714c4))
+
 ## [0.1.0] - 2026-03-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zsync-rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "md4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zsync-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "Efficient file transfer using rsync algorithm over HTTP"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `zsync-rs`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/QaidVoid/zsync-rs/compare/0.1.0...0.1.1) - 2026-03-24

### Added

- Add progress callback support for downloads - ([45ea884](https://github.com/QaidVoid/zsync-rs/commit/45ea884c758382f715353d4323c7dd473fe8d251))

### Other

- Add release profile - ([5de30ce](https://github.com/QaidVoid/zsync-rs/commit/5de30ce78bab9700a7cb10dfb9d3a3f0955714c4))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).