### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [0.1.2](https://github.com/QaidVoid/zsync-rs/compare/0.1.1...0.1.2) - 2026-03-25
+
+### Other
+
+- Use streaming to reduce memory usage - ([63585a4](https://github.com/QaidVoid/zsync-rs/commit/63585a44118778f1fea7646312e059189e3c0fb2))
+
 ## [0.1.1](https://github.com/QaidVoid/zsync-rs/compare/0.1.0...0.1.1) - 2026-03-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zsync-rs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "md4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zsync-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "Efficient file transfer using rsync algorithm over HTTP"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `zsync-rs`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/QaidVoid/zsync-rs/compare/0.1.1...0.1.2) - 2026-03-25

### Other

- Use streaming to reduce memory usage - ([63585a4](https://github.com/QaidVoid/zsync-rs/commit/63585a44118778f1fea7646312e059189e3c0fb2))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).