### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
 
+## [0.1.3](https://github.com/QaidVoid/zsync-rs/compare/0.1.2...0.1.3) - 2026-04-14
+
+### Added
+
+- Add zsyncmake support - ([85001b0](https://github.com/QaidVoid/zsync-rs/commit/85001b022ef42bbd896e630e1566552bd6c8e94a))
+
+### Other
+
+- Add zsyncmake binary to release - ([f509660](https://github.com/QaidVoid/zsync-rs/commit/f5096605ef537bbad940cb0c32b29c75464a7a5a))
+
 ## [0.1.2](https://github.com/QaidVoid/zsync-rs/compare/0.1.1...0.1.2) - 2026-03-25
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,7 +607,7 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zsync-rs"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "clap",
  "md4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zsync-rs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "Efficient file transfer using rsync algorithm over HTTP"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `zsync-rs`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/QaidVoid/zsync-rs/compare/0.1.2...0.1.3) - 2026-04-14

### Added

- Add zsyncmake support - ([85001b0](https://github.com/QaidVoid/zsync-rs/commit/85001b022ef42bbd896e630e1566552bd6c8e94a))

### Other

- Add zsyncmake binary to release - ([f509660](https://github.com/QaidVoid/zsync-rs/commit/f5096605ef537bbad940cb0c32b29c75464a7a5a))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).